### PR TITLE
Refactor Plugins.hpp, launcher changes

### DIFF
--- a/ExamplePlugin/Src/Hello World/SDK/FwdDecls/FwdDecls.hpp
+++ b/ExamplePlugin/Src/Hello World/SDK/FwdDecls/FwdDecls.hpp
@@ -69,7 +69,7 @@ typedef bool (*FNCodeExecute)(YYObjectBase* Self, YYObjectBase* Other, CCode* co
 // Macros
 
 #define WIN32_LEAN_AND_MEAN 1
-#define YYSDK_VERSION "0.0.6" // YYToolkit version - don't change this!
+#define YYSDK_VERSION "0.0.6b" // YYToolkit version - don't change this!
 #define YYTK_MAGIC 'TFSI'
 
 // Macros, but complicated

--- a/ExamplePlugin/Src/Hello World/SDK/Plugins/Plugins.hpp
+++ b/ExamplePlugin/Src/Hello World/SDK/Plugins/Plugins.hpp
@@ -3,15 +3,14 @@
 #define WIN32_LEAN_AND_MEAN 1
 #endif
 #include "../Enums/Enums.hpp"
-#include "YYTKEvent/YYTKEvent.hpp"
 #include <Windows.h>
 #include <dxgiformat.h>
-#include <vector>
-#include <string>
+
 struct CInstance;
 struct YYRValue;
 struct CCode;
 struct YYTKPlugin;
+class YYTKEventBase;
 
 using FNEventHandler = YYTKStatus(*)(YYTKPlugin* pPlugin, YYTKEventBase* pEvent);
 using FNPluginEntry = YYTKStatus(*)(YYTKPlugin* pPlugin);

--- a/ExamplePlugin/Src/Hello World/SDK/SDK.hpp
+++ b/ExamplePlugin/Src/Hello World/SDK/SDK.hpp
@@ -33,3 +33,4 @@
 
 // Plugins.. duh
 #include "Plugins/Plugins.hpp"
+#include "Plugins/YYTKEvent/YYTKEvent.hpp"

--- a/Launcher/Form1.Designer.cs
+++ b/Launcher/Form1.Designer.cs
@@ -339,7 +339,7 @@ namespace Launcher
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "MainWindow";
-            this.Text = "YYLauncher 0.2";
+            this.Text = "YYLauncher 0.0.6b";
             this.gbSelectFiles.ResumeLayout(false);
             this.gbSelectFiles.PerformLayout();
             this.gbMisc.ResumeLayout(false);

--- a/Launcher/Form1.cs
+++ b/Launcher/Form1.cs
@@ -68,9 +68,6 @@ namespace Launcher
 
             using (var Browser = new WebClient())
             {
-                if (File.Exists(TempPath))
-                    File.Delete(TempPath);
-
                 try
                 {
                     Browser.DownloadFile("https://github.com/Archie-osu/YYToolkit/releases/latest/download/YYToolkit.dll", TempPath);

--- a/Launcher/Utils.cs
+++ b/Launcher/Utils.cs
@@ -24,7 +24,7 @@ namespace Launcher
         {
             OpenFileDialog dialog = new OpenFileDialog
             {
-                InitialDirectory = Environment.ExpandEnvironmentVariables(StartPath),
+                //InitialDirectory = Environment.ExpandEnvironmentVariables(StartPath),
                 Title = Title,
                 Filter = Filter,
                 FilterIndex = FilterIndex,

--- a/YYToolkit/Src/Core/Hooks/WindowProc/WindowProc.cpp
+++ b/YYToolkit/Src/Core/Hooks/WindowProc/WindowProc.cpp
@@ -6,6 +6,9 @@ namespace Hooks::WindowProc
 {
 	LRESULT __stdcall Function(HWND hwnd, unsigned int Msg, WPARAM w, LPARAM l)
 	{
+		if (Msg == WM_CLOSE)
+			exit(0);
+
 		YYTKWindowProcEvent Event = YYTKWindowProcEvent(pfnOriginal, hwnd, Msg, w, l);
 		Plugins::RunCallback(&Event);
 

--- a/YYToolkit/Src/Core/SDK/FwdDecls/FwdDecls.hpp
+++ b/YYToolkit/Src/Core/SDK/FwdDecls/FwdDecls.hpp
@@ -69,7 +69,7 @@ typedef bool (*FNCodeExecute)(YYObjectBase* Self, YYObjectBase* Other, CCode* co
 // Macros
 
 #define WIN32_LEAN_AND_MEAN 1
-#define YYSDK_VERSION "0.0.6" // YYToolkit version - don't change this!
+#define YYSDK_VERSION "0.0.6b" // YYToolkit version - don't change this!
 #define YYTK_MAGIC 'TFSI'
 
 // Macros, but complicated

--- a/YYToolkit/Src/Core/SDK/Plugins/Plugins.hpp
+++ b/YYToolkit/Src/Core/SDK/Plugins/Plugins.hpp
@@ -3,15 +3,14 @@
 #define WIN32_LEAN_AND_MEAN 1
 #endif
 #include "../Enums/Enums.hpp"
-#include "YYTKEvent/YYTKEvent.hpp"
 #include <Windows.h>
 #include <dxgiformat.h>
-#include <vector>
-#include <string>
+
 struct CInstance;
 struct YYRValue;
 struct CCode;
 struct YYTKPlugin;
+class YYTKEventBase;
 
 using FNEventHandler = YYTKStatus(*)(YYTKPlugin* pPlugin, YYTKEventBase* pEvent);
 using FNPluginEntry = YYTKStatus(*)(YYTKPlugin* pPlugin);

--- a/YYToolkit/Src/Core/SDK/SDK.hpp
+++ b/YYToolkit/Src/Core/SDK/SDK.hpp
@@ -33,3 +33,4 @@
 
 // Plugins.. duh
 #include "Plugins/Plugins.hpp"
+#include "Plugins/YYTKEvent/YYTKEvent.hpp"


### PR DESCRIPTION
Changes the YYLauncher to remember the directory you chose the runner in, and use that as the starting location.

The Core now handles WM_CLOSE events properly, thus closing the game takes no longer than if YYTK wasn't injected. This behavior overrides plugins.