### PR TITLE
Add support for array manipulation

### DIFF
--- a/YYToolkit/source/YYTK/Module Interface/Interface.hpp
+++ b/YYToolkit/source/YYTK/Module Interface/Interface.hpp
@@ -46,6 +46,10 @@ namespace YYTK
 		// Array of up to 500 builtins
 		RVariableRoutine* m_BuiltinArray = nullptr;
 		int* m_BuiltinCount = nullptr;
+
+		// Needed for RValue array access
+		// RValue* actual_array = (RValue**)(RValue.m_Pointer)[this_value / sizeof(RValue*)];
+		int64_t m_RValueArrayOffset = 0;
 	public:
 		// Stores plugin callbacks
 		std::vector<ModuleCallbackDescriptor> m_RegisteredCallbacks;
@@ -225,6 +229,12 @@ namespace YYTK
 			IN CInstance* TargetInstance,
 			OPTIONAL IN int ArrayIndex,
 			IN RValue& Value
+		) override final;
+
+		virtual Aurie::AurieStatus GetArrayEntry(
+			IN RValue& Value,
+			IN size_t ArrayIndex,
+			OUT RValue*& ArrayElement
 		) override final;
 	};
 

--- a/YYToolkit/source/YYTK/Module Internals/GameMaker/GameMaker.cpp
+++ b/YYToolkit/source/YYTK/Module Internals/GameMaker/GameMaker.cpp
@@ -312,15 +312,14 @@ namespace YYTK
 			// we just skip it. There's functions at the end that are in newer runners,
 			// but not in LTS. Ask nik / nkrapivin for more info.
 			if (mov_displacement >= sizeof(YYRunnerInterface))
-				continue;
-
-			/*
-			CmWriteWarning(
-				"YYRunnerInterface+0x%04llx = 0x%p",
-				mov_displacement,
-				lea.FunctionTarget
-			);
-			*/
+			{
+				CmWriteWarning(
+					"YYRunnerInterface+0x%04llx = 0x%p, but sizeof(YYRunnerInterface) = 0x%llx",
+					mov_displacement,
+					lea.FunctionTarget,
+					sizeof(YYRunnerInterface)
+				);
+			}
 
 			memcpy(
 				interface_base + mov_displacement,
@@ -754,6 +753,153 @@ namespace YYTK
 		return AURIE_SUCCESS;
 	}
 
+	Aurie::AurieStatus GmpFindRVArrayOffset(
+		IN TRoutine F_ArrayEquals, 
+		OUT int64_t* ArrayOffset
+	)
+	{
+		// Okay... this one is a doozy
+		// A TLDR is probably this: We scan for a call to ArrayEquals inside F_ArrayEquals.
+		// Inside ArrayEquals, we look for the access of pArray1->pArray and pArray2->pArray.
+
+		// Decompilation of F_ArrayEquals is this:
+		/*
+			void F_ArrayEquals(
+				OUT RValue& Result,
+				IN CInstance* Self, 
+				IN CInstance* Other, 
+				IN int ArgumentCount, 
+				IN RValue* Arguments
+			)
+			{
+				Result.m_Kind = VALUE_BOOL;
+				Result.m_i64 = 0;
+
+				if (ArgumentCount != 2)
+					YYError("array_equals :: takes 2 arguments");
+
+				RefDynamicArrayOfRValue* first_array = YYGetArray(Arguments, 0, false);
+				RefDynamicArrayOfRValue* second_array = YYGetArray(Arguments, 0, false);
+
+				if (first_array && second_array)
+				{
+					// We find the call to ArrayEquals
+					Result.m_Real = static_cast<double>(ArrayEquals(first_array, second_array) == 0);
+				}
+			}
+		*/
+
+		// So let's disassemble F_ArrayEquals
+		std::vector<TargettedInstruction> instructions = GmpDisassemble(
+			F_ArrayEquals,
+			0xFF,
+			0xFF
+		);
+
+		AurieStatus last_status = AURIE_SUCCESS;
+		size_t start_index = 0;
+
+		// Now look for this pattern
+		// The call instruction target is the ArrayEquals function
+		last_status = GmpFindMnemonicPattern(
+			instructions,
+			{
+				ZYDIS_MNEMONIC_MOV,
+				ZYDIS_MNEMONIC_MOV,
+				ZYDIS_MNEMONIC_CALL
+			},
+			start_index
+		);
+
+		// Make sure we found that
+		if (!AurieSuccess(last_status))
+			return last_status;
+
+		// We know the index of the call instruction is two away from the first mov
+		size_t call_index = start_index + 2;
+		
+		const ZydisDisassembledInstruction& call_instruction = instructions.at(call_index).RawForm;
+		
+		// This should always be the case.
+		// But if it's not, it might cause unforeseen bugs, so we assert that in debug builds
+		assert(call_instruction.info.mnemonic == ZYDIS_MNEMONIC_CALL);
+
+		ZyanU64 array_equals_internal_address = 0;
+		ZydisCalcAbsoluteAddress(
+			&call_instruction.info,
+			&call_instruction.operands[0],
+			call_instruction.runtime_address,
+			&array_equals_internal_address
+		);
+
+		if (!array_equals_internal_address)
+			return AURIE_MODULE_INITIALIZATION_FAILED;
+
+		instructions = GmpDisassemble(
+			reinterpret_cast<PVOID>(array_equals_internal_address),
+			0xFF,
+			0xFF
+		);
+
+		size_t two_movs_index = SIZE_MAX;
+		while (instructions.size())
+		{
+			// Find a potential match
+			last_status = GmpFindMnemonicPattern(
+				instructions,
+				{
+					ZYDIS_MNEMONIC_MOV,
+					ZYDIS_MNEMONIC_MOV
+				},
+				two_movs_index
+			);
+
+			// If no matches exist, end the loop
+			if (!AurieSuccess(last_status))
+			{
+				// Reset the counter
+				two_movs_index = SIZE_MAX;
+				break;
+			}
+
+			ZydisDisassembledInstruction& first_mov = instructions.at(two_movs_index).RawForm;
+			ZydisDisassembledInstruction& second_mov = instructions.at(two_movs_index + 1).RawForm;
+
+			// TODO: I don't know how to invert this properly
+			// To explain this whole thing, we're searching for two consecutive movs that fulfill:
+			// - Moving from some memory addresses (offset by a common value) to (any) registers
+			// - That's about it?
+			if ((first_mov.info.operand_count == 2 && second_mov.info.operand_count == 2) &&
+				(first_mov.operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER && second_mov.operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER) &&
+				(first_mov.operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY && second_mov.operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY) &&
+				(first_mov.operands[1].mem.disp.has_displacement && second_mov.operands[1].mem.disp.has_displacement) &&
+				(first_mov.operands[1].mem.disp.value == second_mov.operands[1].mem.disp.value)
+			)
+			{
+				break;
+			}
+
+			// Create a new vector, starting at where the two movs ended, up until the end of the current vector
+			std::vector<TargettedInstruction> new_instructions(
+				instructions.cbegin() + two_movs_index + 1, instructions.cend()
+			);
+
+			// Move from new_instructions to instructions, effectively replacing them
+			instructions = std::move(new_instructions);
+
+			// Reset the index
+			two_movs_index = SIZE_MAX;
+		}
+
+		// If we couldn't find two movs that match, return an error
+		if (two_movs_index == SIZE_MAX)
+			return AURIE_MODULE_INITIALIZATION_FAILED;
+
+		*ArrayOffset = instructions.at(two_movs_index).RawForm.operands[1].mem.disp.value;
+
+		return AURIE_SUCCESS;
+	}
+
 	Aurie::AurieStatus GmpFindDoCallScript(
 		OUT PVOID* DoCallScript
 	)
@@ -988,5 +1134,41 @@ namespace YYTK
 		}
 
 		return AURIE_SUCCESS;
+	}
+
+	Aurie::AurieStatus GmpFindMnemonicPattern(
+		IN const std::vector<TargettedInstruction>& Instructions, 
+		IN const std::vector<ZydisMnemonic>& Mnemonics, 
+		OUT size_t& StartIndex
+	)
+	{
+		// Loop all instructions in the vector
+		for (size_t start_index = 0; start_index < Instructions.size() - Mnemonics.size(); start_index++)
+		{
+			bool pattern_matches = true;
+
+			// Loop all target mnemonics
+			for (size_t in_pattern_index = 0; in_pattern_index < Mnemonics.size(); in_pattern_index++)
+			{
+				const ZydisMnemonic& actual_mnemonic = Instructions.at(start_index + in_pattern_index).RawForm.info.mnemonic;
+				const ZydisMnemonic& target_mnemonic = Mnemonics.at(in_pattern_index);
+
+				if (actual_mnemonic != target_mnemonic)
+				{
+					pattern_matches = false;
+					break;
+				}
+			}
+
+			// If we didn't set the pattern_matches flag to false, 
+			// that means it matched the whole thing, and we got our start index!
+			if (pattern_matches)
+			{
+				StartIndex = start_index;
+				return AURIE_SUCCESS;
+			}
+		}
+
+		return AURIE_OBJECT_NOT_FOUND;
 	}
 }

--- a/YYToolkit/source/YYTK/Module Internals/Module Internals.hpp
+++ b/YYToolkit/source/YYTK/Module Internals/Module Internals.hpp
@@ -71,6 +71,11 @@ namespace YYTK
 		OUT FNScriptData* ScriptData
 	);
 
+	Aurie::AurieStatus GmpFindRVArrayOffset(
+		IN TRoutine F_ArrayEquals,
+		OUT int64_t* ArrayOffset
+	);
+
 	Aurie::AurieStatus GmpFindDoCallScript(
 		OUT PVOID* DoCallScript
 	);
@@ -86,6 +91,13 @@ namespace YYTK
 		IN const unsigned char* Pattern,
 		IN const char* PatternMask,
 		OUT std::vector<size_t>& Matches
+	);
+
+	// Not game specific, kinda like MmSigscan* but for instructions
+	Aurie::AurieStatus GmpFindMnemonicPattern(
+		IN const std::vector<TargettedInstruction>& Instructions,
+		IN const std::vector<ZydisMnemonic>& Mnemonics,
+		OUT size_t& StartIndex
 	);
 
 	namespace Hooks

--- a/YYToolkit/source/YYTK/Shared.hpp
+++ b/YYToolkit/source/YYTK/Shared.hpp
@@ -165,16 +165,32 @@ namespace YYTK
 		);
 
 		RValue(
+			IN const char* Value
+		);
+
+		RValue(
+			IN std::string_view Value
+		);
+
+		RValue(
 			IN std::string_view Value,
 			IN YYTKInterface* Interface
 		);
 
+		// Custom getters
 		bool AsBool() const;
 
 		double AsReal() const;
 
+		std::string_view AsString();
+
 		std::string_view AsString(
 			IN YYTKInterface* Interface
+		);
+
+		// Overloaded operators
+		RValue& operator[](
+			IN size_t Index
 		);
 	};
 #pragma pack(pop)
@@ -553,6 +569,12 @@ namespace YYTK
 			IN CInstance* TargetInstance,
 			OPTIONAL IN int ArrayIndex,
 			IN RValue& Value
+		) = 0;
+
+		virtual Aurie::AurieStatus GetArrayEntry(
+			IN RValue& Value,
+			IN size_t ArrayIndex,
+			OUT RValue*& ArrayElement
 		) = 0;
 	};
 }

--- a/YYToolkit/source/YYTK/Shared.hpp
+++ b/YYToolkit/source/YYTK/Shared.hpp
@@ -145,6 +145,10 @@ namespace YYTK
 		RValue();
 
 		RValue(
+			IN std::initializer_list<RValue> Values
+		);
+
+		RValue(
 			IN bool Value
 		);
 
@@ -191,6 +195,19 @@ namespace YYTK
 		// Overloaded operators
 		RValue& operator[](
 			IN size_t Index
+		);
+
+		RValue& operator[](
+			IN std::string_view Element
+		);
+
+		// STL-like access
+		RValue& at(
+			IN size_t Index
+		);
+
+		RValue& at(
+			IN std::string_view Element
 		);
 	};
 #pragma pack(pop)
@@ -428,6 +445,19 @@ namespace YYTK
 		double (*extOptGetReal)(const char* _ext, const char* _opt);
 
 		bool (*isRunningFromIDE)();
+	};
+
+	struct CInstance
+	{
+		// Overloaded operators
+		RValue& operator[](
+			IN std::string_view Element
+		);
+
+		// STL-like access
+		RValue& at(
+			IN std::string_view Element
+		);
 	};
 
 	// ExecuteIt


### PR DESCRIPTION
- Added an operator[] for non-const RValues
- Added const char* and std::string_view initializers for RValues that don't require YYTKInterface
- Added a warning for when there's unsupported functions right outside YYRunnerInterface's bounds
- Added API function ``GetArrayEntry`` for getting pointers out of arrays
- Added ``std::initializer_list`` support for inline initialization of RValue arrays
- Added a custom ``operator[]`` overload to ``CInstance`` and ``RValue``objects, allowing direct struct access
- Changed ``GetInstanceMember`` to return ``AURIE_OBJECT_NOT_FOUND`` for when accessing a non-existent struct member
- Added YYTK Shared headers define for easy version identification and comparison with YYTK's QueryVersion result

TODOs:

- [x] Test if GetArrayEntry actually works
- [x] Make documentation for GetArrayEntry
- [x] Test more games than just HoloCure and Sonic.exe