### PR TITLE
Fix EVENT_FRAME/EVENT_RESIZE never firing: InitializeStage3Hooks was never called

### DIFF
--- a/YYToolkit/source/YYTK/Module Interface/MI_Aurie.cpp
+++ b/YYToolkit/source/YYTK/Module Interface/MI_Aurie.cpp
@@ -487,6 +487,21 @@ namespace YYTK
 			return AURIE_MODULE_INTERNAL_ERROR;
 		}
 
+		// Install the D3D11 Present/ResizeBuffers hooks backing EVENT_FRAME
+		// and EVENT_RESIZE now that we have a live swapchain. Without this
+		// call, CreateCallback(..., EVENT_FRAME/EVENT_RESIZE, ...) silently
+		// registers a callback that can never actually fire, since nothing
+		// ever hooks Present()/ResizeBuffers() in the first place.
+		last_status = Hooks::InitializeStage3Hooks(m_WindowHandle, m_EngineSwapchain);
+
+		DbgPrintEx(LOG_SEVERITY_TRACE, "Hooks::InitializeStage3Hooks => %s", AurieStatusToString(last_status));
+
+		if (!AurieSuccess(last_status))
+		{
+			DbgPrintEx(LOG_SEVERITY_CRITICAL, "Failed to create D3D11 hooks!");
+			return AURIE_MODULE_INTERNAL_ERROR;
+		}
+
 		m_ThirdInitComplete = true;
 		return AURIE_SUCCESS;
 	}


### PR DESCRIPTION
## The bug

`EVENT_FRAME`/`EVENT_RESIZE` register successfully via `CreateCallback` but the callback never actually fires, on any registration timing or calling-convention signature. Root cause: `Hooks::InitializeStage3Hooks` (the function that installs the manual VMT hooks on `IDXGISwapChain::Present`/`ResizeBuffers` that these two events depend on) is defined in `Hooks.cpp` but is **never called anywhere in the codebase**.

`YkSetupFinalInitialization()` resolves the live D3D11 swapchain (`m_EngineSwapchain`) via `YkFetchD3D11Info`, specifically so it can be handed to `InitializeStage3Hooks` — but then just sets `m_ThirdInitComplete = true` and returns. The call that would actually install the hooks using that swapchain is missing.

`CreateCallback` has no way to detect this — it just registers into `m_RegisteredCallbacks` and reports `AURIE_SUCCESS` regardless of whether the underlying hook exists. So `EVENT_FRAME`/`EVENT_RESIZE` fail completely silently: no error, no crash, the callback is just permanently unreachable.

## Confirmed via `stable`, and it's a regression from the Zeus rewrite

`stable` has the identical VMT-hooking code (byte-for-byte the same `Present`/`ResizeBuffers` hooking logic, just named `Hooks::HkInitialize` there instead of `InitializeStage3Hooks`) — and it **is called**, right after the swapchain is resolved: [`Interface.cpp:914`](https://github.com/AurieFramework/YYToolkit/blob/stable/YYToolkit/source/YYTK/Module%20Interface/Interface.cpp#L914).

So this isn't a gap that's always existed — it looks like a leftover from the v5 "Zeus" staged-init rewrite that split the old monolithic `Interface.cpp` into `MI_Aurie.cpp`/`MI_Internal.cpp`/`MI_Public.cpp`. `InitializeStage3Hooks` survived the move intact; its one call site did not.

I checked all four hook-installing functions in `experimental`'s `Hooks.cpp` for call sites — `InitializeStage3Hooks` is the only one with zero:

| Function | Backs | Called from |
|---|---|---|
| `InitializeStage1Hooks` (→ `HkExecuteIt`) | `EVENT_OBJECT_CALL` | `MI_Aurie.cpp:80` ✅ |
| `InitializeStage2Hooks` (→ `HkYYError`, `HkWndProc`) | `EVENT_WNDPROC` | `MI_Aurie.cpp:434` ✅ |
| `InitializeStage3Hooks` (→ `HkPresent`, `HkResizeBuffers`) | `EVENT_FRAME`, `EVENT_RESIZE` | nowhere ❌ |

## The fix

Add the missing call in `YkSetupFinalInitialization()`, mirroring the exact call/log/error-check pattern already used for `InitializeStage1Hooks`/`InitializeStage2Hooks` two blocks above in the same function, and mirroring `stable`'s working call site. Uses only `m_WindowHandle`/`m_EngineSwapchain`, both already set earlier in the same init chain.

## Validation — build-tested and live-confirmed

Built this branch (plain MSBuild against `YYToolkit.sln`, no changes needed) and ran it against the real game that surfaced this bug, with a test plugin that registers `EVENT_FRAME` the normal way (`CreateCallback`, no workaround). Confirmed via `aurie.log`'s own trace output that the new call actually runs and succeeds:

```
[20:32:16] Hooks::InitializeStage2Hooks => AURIE_SUCCESS
[20:32:18] Hooks::InitializeStage3Hooks => AURIE_SUCCESS
```

(the ~2s gap is the existing `YkFetchD3D11Info` polling loop waiting for the swapchain — expected.) Every other Zeus subsystem in the log still reports `AURIE_SUCCESS` — nothing else regressed.

Functionally: `EVENT_FRAME` fired on the very first frame after registration and sustained continuous calls with zero gaps for the whole session (GM 2026.0.0.23, LTS, YYC x64 runner), running alongside an unrelated `EVENT_OBJECT_CALL` subscriber the whole time with no interference either direction. Full narrative in the PR comment below.

Happy to answer questions or adjust the approach if there's a reason this call was left out that I'm not seeing.
